### PR TITLE
webusb_fat_mkdir fix path with trailing /

### DIFF
--- a/webusb_fat_mkdir.py
+++ b/webusb_fat_mkdir.py
@@ -108,7 +108,10 @@ if (path.startswith("/flash")):
     path = "/internal" + path[6:]
 if (path.startswith("/sdcard")):
     path = "/sd" + path[7:]
-    
+# Remove trailing /
+if path.endswith("/"):
+    path = path[:-1]
+
 print(path)
 
 payload = path.encode("ascii")


### PR DESCRIPTION
the tool previously failed to create directory if the argument ended with a slash (/)
this fix it