### PR TITLE
add shell.nix for Nix users

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = [
+    (pkgs.python3.withPackages (ps: [ ps.pyusb ]))
+  ];
+}


### PR DESCRIPTION
Allows users of Nix to open a shell with suitable environment set up with a simple `nix-shell` (python in scope with the pyusb package).